### PR TITLE
feat: aj get customer

### DIFF
--- a/src/main/java/com/example/billing/controller/InvoiceRestController.java
+++ b/src/main/java/com/example/billing/controller/InvoiceRestController.java
@@ -27,11 +27,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
@@ -161,6 +163,34 @@ public class InvoiceRestController {
         }
         
         return irspm.InvoiceListToInvoiceResponseList(filteredInvoices);
+    }
+
+    @Operation(
+        description = "Get invoices by customer ID with pagination",
+        summary = "Retrieve all invoices for a specific customer"
+    )
+    @GetMapping("/customer/{customerId}")
+    public Page<InvoiceResponse> getInvoicesByCustomer(
+            @Parameter(description = "Customer ID") @PathVariable String customerId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) throws BusinessRuleException {
+        
+        List<Invoice> allInvoices = billingRepository.findAll();
+        List<Invoice> customerInvoices = allInvoices.stream()
+            .filter(invoice -> customerId.equals(invoice.getCustomerId()))
+            .collect(Collectors.toList());
+        
+        if (customerInvoices.isEmpty()) {
+            throw new BusinessRuleException("NOT_FOUND", "No invoices found for customer: " + customerId, HttpStatus.NOT_FOUND);
+        }
+        
+        Pageable pageable = PageRequest.of(page, size);
+        int start = page * size;
+        int end = Math.min(start + size, customerInvoices.size());
+        List<Invoice> pagedInvoices = customerInvoices.subList(start, end);
+        List<InvoiceResponse> responses = irspm.InvoiceListToInvoiceResponseList(pagedInvoices);
+        
+        return new PageImpl<>(responses, pageable, customerInvoices.size());
     }
 
     private boolean matchesSearchCriteria(Invoice invoice, InvoiceSearchRequest searchRequest) {


### PR DESCRIPTION
This pull request introduces a new endpoint to retrieve invoices by customer ID with pagination in the `InvoiceRestController` class. It also includes minor updates to imports for supporting the new functionality.

### New Feature: Retrieve Invoices by Customer ID with Pagination
* Added a new `@GetMapping` endpoint `/customer/{customerId}` in `InvoiceRestController` to fetch invoices for a specific customer with pagination. The method uses `Pageable` and `PageImpl` to return a paginated response. If no invoices are found for the given customer, a `BusinessRuleException` is thrown. (`[src/main/java/com/example/billing/controller/InvoiceRestController.javaR168-R195](diffhunk://#diff-a89f303324ef6fe957adc8c7a025aa921c0ed5ddb29b82f688985dc997d1c1ecR168-R195)`)

### Supporting Changes:
* Updated imports in `InvoiceRestController` to include `@Parameter` and `PageImpl` for the new endpoint functionality. (`[src/main/java/com/example/billing/controller/InvoiceRestController.javaR30-R36](diffhunk://#diff-a89f303324ef6fe957adc8c7a025aa921c0ed5ddb29b82f688985dc997d1c1ecR30-R36)`)