### PR TITLE
feat: statistics invoice

### DIFF
--- a/src/main/java/com/example/billing/controller/InvoiceRestController.java
+++ b/src/main/java/com/example/billing/controller/InvoiceRestController.java
@@ -12,12 +12,20 @@ import com.example.billing.common.InvoiceResponseMapper;
 import com.example.billing.dto.InvoiceRequest;
 import com.example.billing.dto.InvoiceResponse;
 import com.example.billing.dto.InvoiceSearchRequest;
+import com.example.billing.dto.InvoiceStatsResponse;
 import com.example.billing.entities.Invoice;
 import com.example.billing.exception.BusinessRuleException;
 import com.example.billing.respository.InvoiceRepository;
 
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.DoubleSummaryStatistics;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -193,6 +201,46 @@ public class InvoiceRestController {
         return new PageImpl<>(responses, pageable, customerInvoices.size());
     }
 
+    @Operation(
+        description = "Get comprehensive statistics about invoices",
+        summary = "Return analytics data including totals, averages, and counts"
+    )
+    @GetMapping("/statistics")
+    public InvoiceStatsResponse getInvoiceStatistics() throws BusinessRuleException {
+        List<Invoice> allInvoices = billingRepository.findAll();
+        
+        if (allInvoices.isEmpty()) {
+            throw new BusinessRuleException("NOT_FOUND", "No invoices available for statistics", HttpStatus.NOT_FOUND);
+        }
+        
+        InvoiceStatsResponse stats = new InvoiceStatsResponse();
+        stats.setTotalInvoices(allInvoices.size());
+        
+        DoubleSummaryStatistics amountStats = allInvoices.stream()
+            .mapToDouble(Invoice::getAmount)
+            .summaryStatistics();
+        
+        stats.setTotalAmount(amountStats.getSum());
+        stats.setAverageAmount(amountStats.getAverage());
+        stats.setMaxAmount(amountStats.getMax());
+        stats.setMinAmount(amountStats.getMin());
+        
+        Map<String, Long> customerCounts = allInvoices.stream()
+            .collect(Collectors.groupingBy(Invoice::getCustomerId, Collectors.counting()));
+        stats.setUniqueCustomers(customerCounts.size());
+        stats.setCustomerInvoiceCounts(customerCounts);
+        
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("topCustomerByInvoiceCount", getTopCustomerByCount(customerCounts));
+        metadata.put("topCustomerByAmount", getTopCustomerByAmount(allInvoices));
+        metadata.put("averageInvoicesPerCustomer", (double) allInvoices.size() / customerCounts.size());
+        
+        stats.setMetadata(metadata);
+        stats.setGeneratedAt(LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+        
+        return stats;
+    }
+
     private boolean matchesSearchCriteria(Invoice invoice, InvoiceSearchRequest searchRequest) {
         if (searchRequest.getCustomerId() != null && !searchRequest.getCustomerId().isEmpty()) {
             if (!searchRequest.getCustomerId().equals(invoice.getCustomerId())) {
@@ -244,4 +292,25 @@ public class InvoiceRestController {
                 return java.util.Comparator.comparing(Invoice::getId);
         }
     }
+
+    private String getTopCustomerByCount(Map<String, Long> customerCounts) {
+        return customerCounts.entrySet().stream()
+            .max(Map.Entry.comparingByValue())
+            .map(Map.Entry::getKey)
+            .orElse("N/A");
+    }
+
+    private String getTopCustomerByAmount(List<Invoice> invoices) {
+        Map<String, Double> customerAmounts = invoices.stream()
+            .collect(Collectors.groupingBy(
+                Invoice::getCustomerId,
+                Collectors.summingDouble(Invoice::getAmount)
+            ));
+        
+        return customerAmounts.entrySet().stream()
+            .max(Map.Entry.comparingByValue())
+            .map(Map.Entry::getKey)
+            .orElse("N/A");
+    }
+
 }

--- a/src/main/java/com/example/billing/dto/InvoiceStatsResponse.java
+++ b/src/main/java/com/example/billing/dto/InvoiceStatsResponse.java
@@ -1,0 +1,37 @@
+package com.example.billing.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import java.util.Map;
+
+@Schema(name = "InvoiceStatsResponse", description = "Invoice statistics")
+@Data
+public class InvoiceStatsResponse {
+    
+    @Schema(description = "Total number of invoices", example = "2")
+    private int totalInvoices;
+    
+    @Schema(description = "Sum of all amounts", example = "2533.5")
+    private double totalAmount;
+    
+    @Schema(description = "Average amount", example = "1266.75")
+    private double averageAmount;
+    
+    @Schema(description = "Maximum amount", example = "1333.0")
+    private double maxAmount;
+    
+    @Schema(description = "Minimum amount", example = "1200.5")
+    private double minAmount;
+    
+    @Schema(description = "Number of unique customers", example = "1")
+    private int uniqueCustomers;
+    
+    @Schema(description = "Invoice count per customer")
+    private Map<String, Long> customerInvoiceCounts;
+    
+    @Schema(description = "Additional metadata")
+    private Map<String, Object> metadata;
+    
+    @Schema(description = "Generation timestamp")
+    private String generatedAt;
+}


### PR DESCRIPTION
This pull request introduces a new feature to provide comprehensive statistics about invoices in the billing system. The key changes include the addition of a new API endpoint for retrieving invoice statistics, the creation of a corresponding DTO class, and helper methods to compute analytics data such as totals, averages, and customer-specific metrics.

### New Feature: Invoice Statistics API

* **Added a new API endpoint for invoice statistics**: The `getInvoiceStatistics` method in `InvoiceRestController` provides analytics data, including total invoices, total/average/min/max amounts, unique customer counts, and customer-specific metrics like top customers by invoice count and amount. It also includes metadata such as the average number of invoices per customer.

### Supporting Changes

* **Introduced `InvoiceStatsResponse` DTO**: A new DTO class, `InvoiceStatsResponse`, was added to encapsulate the statistics data returned by the new API endpoint. It includes fields for totals, averages, customer counts, and metadata, with appropriate annotations for Swagger documentation.

* **Added helper methods for analytics computation**: Two new private methods, `getTopCustomerByCount` and `getTopCustomerByAmount`, were added to compute the top customers based on invoice count and total amount, respectively. These methods are used in the new API endpoint to enrich the statistics data.

* **Updated imports in `InvoiceRestController`**: Added necessary imports to support the new functionality, including `InvoiceStatsResponse`, `LocalDateTime`, `DateTimeFormatter`, and `DoubleSummaryStatistics`.