### PR TITLE
feat: aj statistics invoice

### DIFF
--- a/src/test/java/com/example/billing/controller/InvoiceRestControllerTest.java
+++ b/src/test/java/com/example/billing/controller/InvoiceRestControllerTest.java
@@ -303,4 +303,34 @@ class InvoiceRestControllerTest {
                 .param("size", "10"))
                 .andExpect(status().isNotFound());
     }
+
+    @Test
+    @DisplayName("Should get invoice statistics successfully")
+    void shouldGetInvoiceStatisticsSuccessfully() throws Exception {
+        // Given
+        given(billingRepository.findAll()).willReturn(sampleInvoiceList);
+
+        // When & Then
+        mockMvc.perform(get("/billing/v1/statistics"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.totalInvoices").value(2))
+                .andExpect(jsonPath("$.totalAmount").value(2533.5)) // 1200.5 + 1333
+                .andExpect(jsonPath("$.averageAmount").value(1266.75))
+                .andExpect(jsonPath("$.maxAmount").value(1333.0))
+                .andExpect(jsonPath("$.minAmount").value(1200.5))
+                .andExpect(jsonPath("$.uniqueCustomers").value(1))
+                .andExpect(jsonPath("$.customerInvoiceCounts.12").value(2));
+    }
+
+    @Test
+    @DisplayName("Should return 404 for statistics when no invoices")
+    void shouldReturn404ForStatisticsWhenNoInvoices() throws Exception {
+        // Given
+        given(billingRepository.findAll()).willReturn(Collections.emptyList());
+
+        // When & Then
+        mockMvc.perform(get("/billing/v1/statistics"))
+                .andExpect(status().isNotFound());
+    }
 }


### PR DESCRIPTION
This pull request introduces new tests to validate the behavior of the statistics endpoint in the `InvoiceRestController`. These tests ensure proper functionality when retrieving invoice statistics and appropriate handling of cases with no invoices.

### Added Tests for Statistics Endpoint:

* [`shouldGetInvoiceStatisticsSuccessfully`](diffhunk://#diff-e301b6890365d0af57ba65b30fbf12320ba73553862467689dff2821422c8169R306-R335): Verifies that the `/billing/v1/statistics` endpoint returns correct statistics, including total invoices, total amount, average amount, max amount, min amount, unique customers, and customer invoice counts.
* [`shouldReturn404ForStatisticsWhenNoInvoices`](diffhunk://#diff-e301b6890365d0af57ba65b30fbf12320ba73553862467689dff2821422c8169R306-R335): Ensures that the `/billing/v1/statistics` endpoint returns a 404 status when there are no invoices.