### PR TITLE
feat: aj fix deploment

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -6,6 +6,11 @@ metadata:
     app: tesis-demo
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app: tesis-demo
@@ -13,10 +18,13 @@ spec:
     metadata:
       labels:
         app: tesis-demo
+      annotations:
+        deployment.kubernetes.io/revision: "${IMAGE_TAG}"
     spec:
       containers:
       - name: tesis-demo
         image: ${DOCKERHUB_USER}/tesis-demo:${IMAGE_TAG}
+        imagePullPolicy: Always  # CRITICAL: Always pull latest image
         ports:
         - containerPort: 8080
         env:
@@ -36,3 +44,16 @@ spec:
             secretKeyRef:
               name: mongo-secret
               key: mongo-root-password
+        # Health checks
+        livenessProbe:
+          httpGet:
+            path: /actuator/health
+            port: 8080
+          initialDelaySeconds: 60
+          periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /actuator/health
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 10


### PR DESCRIPTION
This pull request introduces several enhancements to the Kubernetes deployment configuration for the `tesis-demo` application. The key changes focus on improving deployment strategies, ensuring image freshness, and adding health checks for better reliability and observability.

### Deployment strategy and image management:
* Updated the deployment strategy to `RollingUpdate` with `maxUnavailable: 0` and `maxSurge: 1` to enable zero-downtime updates. (`k8s/deployment.yaml`, [k8s/deployment.yamlR9-R27](diffhunk://#diff-4bbade0e44f036b32fc63c2e5838f57268ec49ff70dfce1afb9e12849515dd38R9-R27))
* Set `imagePullPolicy` to `Always` to ensure the latest image is pulled for every deployment. (`k8s/deployment.yaml`, [k8s/deployment.yamlR9-R27](diffhunk://#diff-4bbade0e44f036b32fc63c2e5838f57268ec49ff70dfce1afb9e12849515dd38R9-R27))

### Observability and reliability:
* Added `livenessProbe` and `readinessProbe` to monitor application health via the `/actuator/health` endpoint. These probes include appropriate delays and intervals to ensure stability during initialization and operation. (`k8s/deployment.yaml`, [k8s/deployment.yamlR47-R59](diffhunk://#diff-4bbade0e44f036b32fc63c2e5838f57268ec49ff70dfce1afb9e12849515dd38R47-R59))

### Metadata updates:
* Included an annotation for `deployment.kubernetes.io/revision` to track the deployment revision based on the image tag. (`k8s/deployment.yaml`, [k8s/deployment.yamlR9-R27](diffhunk://#diff-4bbade0e44f036b32fc63c2e5838f57268ec49ff70dfce1afb9e12849515dd38R9-R27))