### PR TITLE
feat: aj deploy fix resolve

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -6,11 +6,6 @@ metadata:
     app: tesis-demo
 spec:
   replicas: 1
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 1
   selector:
     matchLabels:
       app: tesis-demo
@@ -18,14 +13,10 @@ spec:
     metadata:
       labels:
         app: tesis-demo
-      annotations:
-        # Force pod restart on every deployment
-        deployment.kubernetes.io/revision: "${IMAGE_TAG}"
     spec:
       containers:
       - name: tesis-demo
         image: ${DOCKERHUB_USER}/tesis-demo:${IMAGE_TAG}
-        imagePullPolicy: Always  # CRITICAL: Always pull latest image
         ports:
         - containerPort: 8080
         env:
@@ -45,43 +36,3 @@ spec:
             secretKeyRef:
               name: mongo-secret
               key: mongo-root-password
-        - name: APP_USER
-          value: "admin"
-        
-        # Health checks - FIXED to use correct actuator endpoints
-        livenessProbe:
-          httpGet:
-            path: /actuator/health
-            port: 8080
-          initialDelaySeconds: 90  # Increased to allow app startup
-          periodSeconds: 30
-          timeoutSeconds: 10
-          failureThreshold: 5
-          
-        readinessProbe:
-          httpGet:
-            path: /actuator/health
-            port: 8080
-          initialDelaySeconds: 60  # Increased to allow app startup
-          periodSeconds: 15
-          timeoutSeconds: 5
-          failureThreshold: 3
-          
-        # Startup probe - for slow starting applications
-        startupProbe:
-          httpGet:
-            path: /actuator/health
-            port: 8080
-          initialDelaySeconds: 30
-          periodSeconds: 10
-          timeoutSeconds: 5
-          failureThreshold: 12  # Allow up to 2 minutes for startup
-          
-        # Resource limits (optional but recommended)
-        resources:
-          requests:
-            memory: "256Mi"
-            cpu: "250m"
-          limits:
-            memory: "512Mi"
-            cpu: "500m"

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,28 +1,12 @@
-# Server Configuration
 server.port=8080
 spring.session.timeout=900
-
-# Data Configuration
 spring.data.web.pageable.default-page-size=10
 spring.data.web.pageable.max-page-size=50
 
-# MongoDB Configuration
+# MongoDB connection string
 spring.data.mongodb.database=billingapp_db
-# Use environment variable for MongoDB URI in Kubernetes
-spring.data.mongodb.uri=mongodb://${MONGO_USER:user}:${MONGO_PASSWORD:qwerty}@${MONGO_HOST:192.168.1.44}:${MONGO_PORT:30413}/${MONGO_DB:billingapp_db}?authSource=admin
+spring.data.mongodb.uri=mongodb://user:qwerty@192.168.1.44:30413/billingapp_db?authSource=admin
 
-# Actuator Configuration (CRITICAL for Kubernetes health checks)
-management.endpoints.enabled-by-default=true
-management.endpoints.web.exposure.include=health,info,metrics
-management.endpoint.health.enabled=true
-management.endpoint.health.show-details=always
-management.health.defaults.enabled=true
-
-# Security for Actuator (allow access without authentication)
-management.endpoints.web.base-path=/actuator
-management.security.enabled=false
-
-# Swagger/OpenAPI Configuration
 springdoc.api-docs.enabled=true
 springdoc.swagger-ui.enabled=true
 springdoc.swagger-ui.use-root-path=true
@@ -31,10 +15,6 @@ springdoc.show-login-endpoint=true
 springdoc.packagesToScan=com.example.billing.entities, com.example.billing.controller
 springdoc.pathsToMatch=/v1, /billing/**
 
-# Remove duplicate security user configuration (handled in SecurityConfiguration.java)
-# spring.security.user.name=${APP_USER:admin}
-# spring.security.user.password=${APP_USER:admin}
-# spring.security.user.roles=ADMIN
-
-# Application Configuration
-app.user=${APP_USER:admin}
+spring.security.user.name=${APP_USER:admin}
+spring.security.user.password=${APP_USER:admin}
+spring.security.user.roles=ADMIN


### PR DESCRIPTION
This pull request simplifies the Kubernetes deployment configuration and application properties by removing unused or redundant settings, streamlining health checks, and improving maintainability. The key changes include the removal of Kubernetes-specific configurations, adjustments to application properties for MongoDB and security, and a cleanup of resource limits and probes.

### Kubernetes Deployment Configuration Changes:

* Removed the `strategy` section (`RollingUpdate`) and annotations for pod restarts in `k8s/deployment.yaml`, simplifying the deployment strategy.
* Removed health checks (`livenessProbe`, `readinessProbe`, `startupProbe`) and resource limits from the deployment specification, likely to streamline the configuration for simpler environments.

### Application Properties Cleanup:

* Simplified the MongoDB connection string by removing environment variable placeholders and unnecessary comments in `application.properties`.
* Removed actuator management configurations for Kubernetes health checks, as these are no longer required in the current setup.
* Reintroduced security user configurations (`spring.security.user.name`, `spring.security.user.password`, `spring.security.user.roles`) directly in `application.properties`, replacing the previously commented-out lines.