### PR TITLE
feat: aj amount range invoice

### DIFF
--- a/src/main/java/com/example/billing/controller/InvoiceRestController.java
+++ b/src/main/java/com/example/billing/controller/InvoiceRestController.java
@@ -241,6 +241,33 @@ public class InvoiceRestController {
         return stats;
     }
 
+    @Operation(
+        description = "Get invoices within a specific amount range",
+        summary = "Filter invoices by minimum and maximum amount"
+    )
+    @GetMapping("/amount-range")
+    public List<InvoiceResponse> getInvoicesByAmountRange(
+            @Parameter(description = "Minimum amount") @RequestParam double minAmount,
+            @Parameter(description = "Maximum amount") @RequestParam double maxAmount) throws BusinessRuleException {
+        
+        if (minAmount > maxAmount) {
+            throw new BusinessRuleException("INVALID_RANGE", "Minimum amount cannot be greater than maximum amount", HttpStatus.BAD_REQUEST);
+        }
+        
+        List<Invoice> allInvoices = billingRepository.findAll();
+        List<Invoice> filteredInvoices = allInvoices.stream()
+            .filter(invoice -> invoice.getAmount() >= minAmount && invoice.getAmount() <= maxAmount)
+            .collect(Collectors.toList());
+        
+        if (filteredInvoices.isEmpty()) {
+            throw new BusinessRuleException("NOT_FOUND", 
+                String.format("No invoices found in amount range %.2f - %.2f", minAmount, maxAmount), 
+                HttpStatus.NOT_FOUND);
+        }
+        
+        return irspm.InvoiceListToInvoiceResponseList(filteredInvoices);
+    }
+
     private boolean matchesSearchCriteria(Invoice invoice, InvoiceSearchRequest searchRequest) {
         if (searchRequest.getCustomerId() != null && !searchRequest.getCustomerId().isEmpty()) {
             if (!searchRequest.getCustomerId().equals(invoice.getCustomerId())) {


### PR DESCRIPTION
This pull request adds a new feature to filter invoices by a specific amount range in the `InvoiceRestController`. The most important change introduces a new endpoint to handle this functionality.

### New Feature: Filter Invoices by Amount Range
* Added a new `@GetMapping` endpoint `/amount-range` in `InvoiceRestController` to retrieve invoices within a specified minimum and maximum amount range. This includes input validation to ensure the minimum amount is not greater than the maximum amount and appropriate exception handling for invalid ranges or when no invoices are found. (`src/main/java/com/example/billing/controller/InvoiceRestController.java`, [src/main/java/com/example/billing/controller/InvoiceRestController.javaR244-R270](diffhunk://#diff-a89f303324ef6fe957adc8c7a025aa921c0ed5ddb29b82f688985dc997d1c1ecR244-R270))