### PR TITLE
fix: amount range resolve

### DIFF
--- a/src/main/java/com/example/billing/controller/InvoiceRestController.java
+++ b/src/main/java/com/example/billing/controller/InvoiceRestController.java
@@ -247,8 +247,8 @@ public class InvoiceRestController {
     )
     @GetMapping("/amount-range")
     public List<InvoiceResponse> getInvoicesByAmountRange(
-            @Parameter(description = "Minimum amount") @RequestParam double minAmount,
-            @Parameter(description = "Maximum amount") @RequestParam double maxAmount) throws BusinessRuleException {
+            @Parameter(description = "Minimum amount") @RequestParam("minAmount") double minAmount,
+            @Parameter(description = "Maximum amount") @RequestParam("maxAmount") double maxAmount) throws BusinessRuleException {
         
         if (minAmount > maxAmount) {
             throw new BusinessRuleException("INVALID_RANGE", "Minimum amount cannot be greater than maximum amount", HttpStatus.BAD_REQUEST);


### PR DESCRIPTION
This pull request includes a small change to the `getInvoicesByAmountRange` method in `InvoiceRestController.java`. The change explicitly maps the `minAmount` and `maxAmount` parameters to their corresponding request parameters using `@RequestParam("...")`.

* [`src/main/java/com/example/billing/controller/InvoiceRestController.java`](diffhunk://#diff-a89f303324ef6fe957adc8c7a025aa921c0ed5ddb29b82f688985dc997d1c1ecL250-R251): Updated the `@RequestParam` annotations for `minAmount` and `maxAmount` to explicitly specify their parameter names.