### PR TITLE
feat: aj test amount range

### DIFF
--- a/src/test/java/com/example/billing/controller/InvoiceRestControllerTest.java
+++ b/src/test/java/com/example/billing/controller/InvoiceRestControllerTest.java
@@ -333,4 +333,34 @@ class InvoiceRestControllerTest {
         mockMvc.perform(get("/billing/v1/statistics"))
                 .andExpect(status().isNotFound());
     }
+
+    
+
+    @Test
+    @DisplayName("Should get invoices by amount range successfully")
+    void shouldGetInvoicesByAmountRangeSuccessfully() throws Exception {
+        // Given
+        given(billingRepository.findAll()).willReturn(sampleInvoiceList);
+        given(invoiceResponseMapper.InvoiceListToInvoiceResponseList(anyList()))
+                .willReturn(sampleResponseList);
+
+        // When & Then
+        mockMvc.perform(get("/billing/v1/amount-range")
+                .param("minAmount", "1200")
+                .param("maxAmount", "1400"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].amount").value(1200.5))
+                .andExpect(jsonPath("$[1].amount").value(1333.0));
+    }
+
+    @Test
+    @DisplayName("Should return 400 for invalid amount range")
+    void shouldReturn400ForInvalidAmountRange() throws Exception {
+        // When & Then - minAmount > maxAmount
+        mockMvc.perform(get("/billing/v1/amount-range")
+                .param("minAmount", "1500")
+                .param("maxAmount", "1000"))
+                .andExpect(status().isBadRequest());
+    }
 }


### PR DESCRIPTION
This pull request adds new test cases to improve the coverage of the `InvoiceRestController` in the billing module. The changes include tests for fetching invoices by an amount range and for handling invalid input.

### Added test cases for `InvoiceRestController`:

* **Positive test case:** Added a test to verify that invoices can be fetched successfully within a valid amount range. The test mocks the repository and mapper, performs a request with `minAmount` and `maxAmount` parameters, and checks for a 200 OK response with the expected JSON content. (`[src/test/java/com/example/billing/controller/InvoiceRestControllerTest.javaR336-R365](diffhunk://#diff-e301b6890365d0af57ba65b30fbf12320ba73553862467689dff2821422c8169R336-R365)`)
* **Negative test case:** Added a test to ensure that the API returns a 400 Bad Request response when the `minAmount` parameter is greater than the `maxAmount` parameter. (`[src/test/java/com/example/billing/controller/InvoiceRestControllerTest.javaR336-R365](diffhunk://#diff-e301b6890365d0af57ba65b30fbf12320ba73553862467689dff2821422c8169R336-R365)`)