### PR TITLE
feat: test bulk invoices deletion

### DIFF
--- a/src/test/java/com/example/billing/controller/InvoiceRestControllerTest.java
+++ b/src/test/java/com/example/billing/controller/InvoiceRestControllerTest.java
@@ -507,4 +507,33 @@ class InvoiceRestControllerTest {
                 .andExpect(jsonPath("$.errorCount").value(1))
                 .andExpect(jsonPath("$.errors[0]").value(Matchers.containsString("Customer ID is required")));
     }
+
+    @Test
+    @DisplayName("Should delete bulk invoices successfully")
+    void shouldDeleteBulkInvoicesSuccessfully() throws Exception {
+        // Given
+        List<String> invoiceIds = Arrays.asList(
+                "3d646c6d-0ae1-453a-9203-227bb0acb7f7", 
+                "1ca2a007-42ae-455d-aa1f-a9f21edc2a56"
+        );
+
+        given(billingRepository.findById("3d646c6d-0ae1-453a-9203-227bb0acb7f7"))
+                .willReturn(Optional.of(sampleInvoice1));
+        given(billingRepository.findById("1ca2a007-42ae-455d-aa1f-a9f21edc2a56"))
+                .willReturn(Optional.of(sampleInvoice2));
+
+        // When & Then
+        mockMvc.perform(delete("/billing/v1/bulk")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(invoiceIds)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.successCount").value(2))
+                .andExpect(jsonPath("$.errorCount").value(0))
+                .andExpect(jsonPath("$.operationType").value("BULK_DELETE"));
+
+        verify(billingRepository).delete(sampleInvoice1);
+        verify(billingRepository).delete(sampleInvoice2);
+    }
 }


### PR DESCRIPTION
This pull request adds a new test case to the `InvoiceRestControllerTest` class to ensure bulk invoice deletion functionality is working as expected.

### Additions to test coverage:

* Added a new test method, `shouldDeleteBulkInvoicesSuccessfully`, to verify that bulk invoice deletion works correctly. The test checks that two invoices are successfully deleted without errors and validates the response structure and content. (`src/test/java/com/example/billing/controller/InvoiceRestControllerTest.java`, [src/test/java/com/example/billing/controller/InvoiceRestControllerTest.javaR510-R538](diffhunk://#diff-e301b6890365d0af57ba65b30fbf12320ba73553862467689dff2821422c8169R510-R538))